### PR TITLE
BUGFIX PHP explode depreciation fix

### DIFF
--- a/src/view/HTMLTag.php
+++ b/src/view/HTMLTag.php
@@ -133,7 +133,7 @@ class HTMLTag extends ViewableData
     public function setClass($value)
     {
         $classes = [];
-        foreach (explode(' ', $value) as $class) {
+        foreach (explode(' ', $value ?? '') as $class) {
             $classes[$class] = $class;
         }
         $this->classes = $classes;


### PR DESCRIPTION
`gorriecoe/silverstripe-embed` of which DNA maintains a fork (RIP Gorrie) relies on this moudle... which currently issues deprecation errors due to the patched line.

https://github.com/dnadesign/silverstripe-embed/blob/900506094da3bef76aa68eaeae9b8fc0df0f109b/composer.json#L20-L29